### PR TITLE
feat(nix): add simplex-chat to server config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,9 @@
     tofi-emoji.url = "github:noahpro99/tofi-emoji";
     aether.url = "github:noahpro99/aether/nixos";
     hyprland-preview-share-picker.url = "git+https://github.com/WhySoBad/hyprland-preview-share-picker?submodules=1";
+
+    # SimpleX Chat (terminal CLI) — upstream flake
+    simplex-chat.url = "github:simplex-chat/simplex-chat/stable";
   };
 
   outputs =
@@ -23,6 +26,7 @@
       tofi-emoji,
       aether,
       hyprland-preview-share-picker,
+      simplex-chat,
       ...
     }@inputs:
     {

--- a/nixos/server.nix
+++ b/nixos/server.nix
@@ -30,6 +30,7 @@
     ];
   };
   environment.systemPackages = with pkgs; [
+    inputs.simplex-chat.packages."${pkgs.stdenv.hostPlatform.system}"."exe:simplex-chat"
     wget
     pass
     stow


### PR DESCRIPTION
This PR adds the upstream simplex-chat flake and includes the CLI package in the `server.nix` configuration. It also adds a placeholder file to resolve a flake check error.